### PR TITLE
Revert "change values in setup.py to match the one in __init__.py. no…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ plugin_package = "octoprint_thespaghettidetective_beta"
 
 # The plugin's human readable name. Can be overwritten within OctoPrint's internal data via __plugin_name__ in the
 # plugin module
-plugin_name = "The Spaghetti Detective (Beta)"
+plugin_name = "TheSpaghettiDetectiveBeta"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
 plugin_version = "0.4.0"
@@ -23,13 +23,13 @@ AI-based open source project for 3D printing failure detection.
 """
 
 # The plugin's author. Can be overwritten within OctoPrint's internal data via __plugin_author__ in the plugin module
-plugin_author = "The Spaghetti Detective Team"
+plugin_author = "The Spaghetti Detective"
 
 # The plugin's author's mail address.
 plugin_author_email = "admin@thespaghettidetective.com"
 
 # The plugin's homepage URL. Can be overwritten within OctoPrint's internal data via __plugin_url__ in the plugin module
-plugin_url = "https://thespaghettidetective.com"
+plugin_url = "https://github.com/TheSpaghettiDetective/TheSpaghettiDetective"
 
 # The plugin's license. Can be overwritten within OctoPrint's internal data via __plugin_license__ in the plugin module
 plugin_license = "AGPLv3"


### PR DESCRIPTION
The commit changing the plugin name in setup.py stopped the plugin from installing for me.  I locally reverted the change and it installed fine. 
This reverts commit 73c5e23c7d11297de237a8d9a61d83bcb695b0bd.