### PR TITLE
Prevent video feed from triggering a post

### DIFF
--- a/octoprint_thespaghettidetective_beta/print_event.py
+++ b/octoprint_thespaghettidetective_beta/print_event.py
@@ -9,6 +9,10 @@ class PrintEventTracker:
         self.current_print_ts = -1    # timestamp as print_ts coming from octoprint
 
     def on_event(self, plugin, event, payload):
+        #Cancel if event is about timelapse (this happends when jpgs are sent to TSD)
+        if event == 'CaptureStart' or event == 'CaptureDone':
+            return
+        
         print_ts = self.current_print_ts
 
         if event == 'PrintStarted':


### PR DESCRIPTION
Prevent the image capture events (time lapse) from triggering a post_printer_status for every frame that is sent to the server.

This was causing an issue where octoprint_data never gets sent during a print and therefore the printer temperatures never update.