### PR TITLE
Improve memory protection scripts

### DIFF
--- a/octoprint_thespaghettidetective/bin/gst/kill_leaked_gst.sh
+++ b/octoprint_thespaghettidetective/bin/gst/kill_leaked_gst.sh
@@ -2,13 +2,12 @@
 
 while true; do
   sleep 5
-  gst_line=$(top -b -n 1 | grep gst-launch-1.0 | sed 's/ \+/:/g')
-  echo $gst_line
-  if [ -z "$gst_line" ]; then
+  resMem=$(ps -o rss= $(pgrep gst-launch-1.0))
+  if [ -z "$resMem" ]; then
     continue
   fi
 
-  if [ $(echo $gst_line | cut -d : -f 6) -gt $1 ]; then
-      kill $(echo $gst_line | cut -d : -f 1)
+  if [ $resMem -gt $1 ]; then
+      kill $(pgrep gst-launch-1.0)
   fi
 done

--- a/octoprint_thespaghettidetective/webcam_stream.py
+++ b/octoprint_thespaghettidetective/webcam_stream.py
@@ -97,7 +97,7 @@ class WebcamStreamer:
                 self.webcam_server = UsbCamWebServer(self.sentry)
                 self.webcam_server.start()
 
-                self.start_gst_memroy_guard()
+                self.start_gst_memory_guard()
                 self.start_gst()
 
             # Use ffmpeg for Pi Camera. When it's used for USB Camera it has problems (SPS/PPS not sent in-band?)
@@ -213,7 +213,7 @@ class WebcamStreamer:
         gst_thread.daemon = True
         gst_thread.start()
 
-    def start_gst_memroy_guard(self):
+    def start_gst_memory_guard(self):
         # Hack to deal with gst command that causes memory leak
         kill_leaked_gst_cmd = '{} 200000'.format(os.path.join(GST_DIR, 'kill_leaked_gst.sh'))
         _logger.debug('Popen: {}'.format(kill_leaked_gst_cmd))


### PR DESCRIPTION
a few major differences:

- use pgrep to get the pid where needed
- use some flags to ps to get just the resident memory (```-o rss``` limits to resident memory, the = drops the headers - the output is a single line for just the gst-launch-1.0 process' resident memory

I think the issue may be a setting or configuration that causes different orders of results from top and ps.  Using more flags to narrow down to just what we want removes a lot of potential pitfalls.