### PR TITLE
Fix for token test api endpoint when its tunneled 

### DIFF
--- a/octoprint_thespaghettidetective/static/js/TheSpaghettiDetective.js
+++ b/octoprint_thespaghettidetective/static/js/TheSpaghettiDetective.js
@@ -7,7 +7,12 @@
 $(function () {
 
     function apiCommand(data, success) {
-        $.ajax("api/plugin/thespaghettidetective", {
+        var path = window.location.pathname;
+        if (!path.endsWith("/")) {
+          path = path + "/"
+        }
+
+        $.ajax(path + "api/plugin/thespaghettidetective", {
             method: "POST",
             contentType: "application/json",
             data: JSON.stringify(data),


### PR DESCRIPTION
Realtive ajax url clears last path segment when base tunnel page does not end in "/" (like in "/octoprint/2" )