### PR TITLE
Prevent janus from listening on public interfaces

### DIFF
--- a/octoprint_thespaghettidetective/bin/janus/etc/janus/janus.transport.http.jcfg
+++ b/octoprint_thespaghettidetective/bin/janus/etc/janus/janus.transport.http.jcfg
@@ -18,7 +18,7 @@ general: {
 	http = true						# Whether to enable the plain HTTP interface
 	port = 8088						# Web server HTTP port
 	#interface = "eth0"				# Whether we should bind this server to a specific interface only
-	#ip = "192.168.0.1"				# Whether we should bind this server to a specific IP address (v4 or v6) only
+	ip = "127.0.0.1"				# Whether we should bind this server to a specific IP address (v4 or v6) only
 	https = false					# Whether to enable HTTPS (default=false)
 	#secure_port = 8089				# Web server HTTPS port, if enabled
 	#secure_interface = "eth0"		# Whether we should bind this server to a specific interface only
@@ -43,7 +43,7 @@ admin: {
 	admin_http = true                   # Whether to enable the plain HTTP interface
 	admin_port = 7088					# Admin/monitor web server HTTP port
 	#admin_interface = "eth0"			# Whether we should bind this server to a specific interface only
-	#admin_ip = "192.168.0.1"			# Whether we should bind this server to a specific IP address (v4 or v6) only
+	admin_ip = "127.0.0.1"			# Whether we should bind this server to a specific IP address (v4 or v6) only
 	admin_https = false					# Whether to enable HTTPS (default=false)
 	#admin_secure_port = 7889			# Admin/monitor web server HTTPS port, if enabled
 	#admin_secure_interface = "eth0"	# Whether we should bind this server to a specific interface only

--- a/octoprint_thespaghettidetective/bin/janus/etc/janus/janus.transport.websockets.jcfg
+++ b/octoprint_thespaghettidetective/bin/janus/etc/janus/janus.transport.websockets.jcfg
@@ -9,7 +9,7 @@ general: {
 	ws = true						# Whether to enable the WebSockets API
 	ws_port = 8188					# WebSockets server port
 	#ws_interface = "eth0"			# Whether we should bind this server to a specific interface only
-	#ws_ip = "192.168.0.1"			# Whether we should bind this server to a specific IP address only
+	ws_ip = "127.0.0.1"			# Whether we should bind this server to a specific IP address only
 	wss = false						# Whether to enable secure WebSockets
 	#wss_port = 8989				# WebSockets server secure port, if enabled
 	#wss_interface = "eth0"			# Whether we should bind this server to a specific interface only


### PR DESCRIPTION
This should resolve https://github.com/TheSpaghettiDetective/TheSpaghettiDetective/issues/343.
Note that I used the IPv4 address for all 3, and that this will break on setups that are IPv6-only.
