### PR TITLE
Implementation for "Printer discovery" feature (plugin side)

### DIFF
--- a/octoprint_thespaghettidetective/__init__.py
+++ b/octoprint_thespaghettidetective/__init__.py
@@ -32,7 +32,7 @@ from .tunnel import LocalTunnel
 from . import plugin_apis
 from .client_conn import ClientConn
 import zlib
-from .linkhelper import LinkHelper
+from .printer_discovery import PrinterDiscovery
 
 import octoprint.plugin
 
@@ -195,10 +195,10 @@ class TheSpaghettiDetectivePlugin(
 
         get_tags()  # init tags to minimize risk of race condition
 
-        lhelper = None
+        pdiscovery = None
         if not self.is_configured():
-            lhelper = LinkHelper(plugin=self)
-            lhelper.start()
+            pdiscovery = PrinterDiscovery(plugin=self)
+            pdiscovery.start()
 
         self.linked_printer = self.wait_for_auth_token().get('printer', DEFAULT_LINKED_PRINTER)
 

--- a/octoprint_thespaghettidetective/__init__.py
+++ b/octoprint_thespaghettidetective/__init__.py
@@ -198,14 +198,9 @@ class TheSpaghettiDetectivePlugin(
         lhelper = None
         if not self.is_configured():
             lhelper = LinkHelper(plugin=self)
-            lhelper_thread = threading.Thread(target=lhelper.start)
-            lhelper_thread.daemon = True
-            lhelper_thread.start()
+            lhelper.start()
 
         self.linked_printer = self.wait_for_auth_token().get('printer', DEFAULT_LINKED_PRINTER)
-
-        if lhelper:
-            lhelper.stop()
 
         self.sentry.user_context({'id': self.auth_token()})
         _logger.info('Linked printer: {}'.format(self.linked_printer))

--- a/octoprint_thespaghettidetective/linkhelper.py
+++ b/octoprint_thespaghettidetective/linkhelper.py
@@ -64,9 +64,7 @@ class LinkHelper(object):
                 break
 
             if self.plugin.is_configured():
-                # TODO if any token is set, let's never try to overwrite that
-                # for now.
-                # Question: what to do when existing token is invalid?
+                # if any token is set, let's stop
                 break
 
             if time.time() - self.started_at > self.deadline_secs:
@@ -120,9 +118,7 @@ class LinkHelper(object):
         _logger.info('linkhelper incoming msg: {}'.format(msg))
 
         if msg['type'] == 'verify_code':
-            # TODO if any token is set, let's never try to overwrite that
-            # for now.
-            # Question: what to do when existing token is invalid?
+            # if any token is set, let's stop
             if self.plugin.is_configured():
                 return
 

--- a/octoprint_thespaghettidetective/linkhelper.py
+++ b/octoprint_thespaghettidetective/linkhelper.py
@@ -48,8 +48,8 @@ class LinkHelper(object):
             octopi_version=read('/etc/octopi_version'),
         )
 
-    def start(self) -> None:
-        _logger.info(f'linkhelper started, device_id: {self.device_id}')
+    def start(self):
+        _logger.info('linkhelper started, device_id: {}'.format(self.device_id))
 
         self.started_at = time.time()
         next_connect_at = 0.0  # -inf

--- a/octoprint_thespaghettidetective/linkhelper.py
+++ b/octoprint_thespaghettidetective/linkhelper.py
@@ -1,0 +1,157 @@
+from typing import Optional
+import time
+import logging
+import os
+import uuid
+import io
+import json
+
+import octoprint.server
+from octoprint.util.platform import (
+    get_os as octoprint_get_os,
+    OPERATING_SYSTEM_UNMAPPED
+)
+
+from .plugin_apis import verify_code
+from .utils import ExpoBackoff, server_request
+
+_logger = logging.getLogger('octoprint.plugins.thespaghettidetective')
+
+POLL_PERIOD_SECS = 5
+DEADLINE_SECS = 1800
+MAX_BACKOFF_SECS = 300
+
+
+class LinkHelper(object):
+
+    def __init__(self,
+                 plugin,
+                 poll_period_secs=POLL_PERIOD_SECS,
+                 deadline_secs=DEADLINE_SECS,
+                 max_backoff_secs=MAX_BACKOFF_SECS
+                 ):
+        self.plugin = plugin
+        self.poll_period_secs = poll_period_secs  # type: int
+        self.deadline_secs = deadline_secs  # type: int
+        self.max_backoff_secs = max_backoff_secs  # type: int
+        self.stopped = False
+        self.started_at = None  # type: Optional[float]
+
+        # device_id is different every time plugin starts
+        self.device_id = uuid.uuid4().hex  # type: str
+        self.static_info = dict(
+            device_id=self.device_id,
+            hostname=os.uname()[1],
+            os=get_os(),
+            arch=os.uname()[4],
+            rpi_model=read('/proc/device-tree/model'),
+            octopi_version=read('/etc/octopi_version'),
+        )
+
+    def start(self) -> None:
+        _logger.info(f'linkhelper started, device_id: {self.device_id}')
+
+        self.started_at = time.time()
+        next_connect_at = 0.0  # -inf
+        connect_attempts = 0
+
+        while True:
+            if self.stopped:
+                break
+
+            if self.plugin.is_configured():
+                # TODO if any token is set, let's never try to overwrite that
+                # for now.
+                # Question: what to do when existing token is invalid?
+                break
+
+            if time.time() - self.started_at > self.deadline_secs:
+                _logger.info('linkhelper deadline reached')
+                self.stop()
+                break
+
+            if time.time() > next_connect_at:
+                try:
+                    self._call()
+                    connect_attempts = 0
+                    next_connect_at = time.time() + self.poll_period_secs
+                except Exception as ex:
+                    backoff_time = ExpoBackoff.get_delay(
+                        connect_attempts, self.max_backoff_secs)
+                    _logger.debug(
+                        'linkhelper error ({}), will retry after {}s'.format(
+                            ex, backoff_time))
+
+                    connect_attempts += 1
+                    next_connect_at = time.time() + backoff_time
+
+            time.sleep(2)
+        _logger.info('linkhelper stopped')
+
+    def stop(self):
+        self.stopped = True
+
+    def _call(self):
+        _logger.debug('linkhelper calls server')
+        data = self._collect_device_info()
+
+        resp = server_request(
+            'POST',
+            '/api/v1/octo/unlinked/',
+            self.plugin,
+            timeout=5,
+            data=json.dumps(data),
+            headers={'Content-Type': 'application/json'}
+        )
+
+        if resp is None:
+            raise Exception('network error')
+
+        resp.raise_for_status()
+        data = resp.json()
+        for msg in data['messages']:
+            self._process_message(msg)
+
+    def _process_message(self, msg):
+        _logger.info('linkhelper incoming msg: {}'.format(msg))
+
+        if msg['type'] == 'verify_code':
+            # TODO if any token is set, let's never try to overwrite that
+            # for now.
+            # Question: what to do when existing token is invalid?
+            if self.plugin.is_configured():
+                return
+
+            if msg['device_id'] != self.device_id:
+                _logger.debug('linkhelper got message for different device_id')
+                return
+
+            result = verify_code(self.plugin, msg['data'])
+            if result['succeeded'] is True:
+                _logger.info('linkhelper verified code succesfully')
+                self.stop()
+            else:
+                _logger.warn('linkhelper could not verify code')
+            return
+
+    def _collect_device_info(self):
+        info = dict(**self.static_info)
+        if hasattr(octoprint.server, 'printerProfileManager'):
+            printerprofile = octoprint.server.printerProfileManager.get_current()
+            info['printerprofile'] = printerprofile.get('name', '') if printerprofile else ''
+        return info
+
+
+def get_os():  # type: () -> str
+    os_name = octoprint_get_os()
+    if os_name == OPERATING_SYSTEM_UNMAPPED:
+        os_name = ''
+    return os_name or ''
+
+
+def read(path):  # type: (str) -> str
+    try:
+        with io.open(path, 'rt', encoding='utf8') as f:
+            return f.readline().strip('\0').strip()
+    except Exception:
+        return ''

--- a/octoprint_thespaghettidetective/printer_discovery.py
+++ b/octoprint_thespaghettidetective/printer_discovery.py
@@ -23,7 +23,7 @@ DEADLINE_SECS = 1800
 MAX_BACKOFF_SECS = 300
 
 
-class LinkHelper(object):
+class PrinterDiscovery(object):
 
     def __init__(self,
                  plugin,
@@ -53,7 +53,7 @@ class LinkHelper(object):
         self.ip = None
 
     def start(self):
-        _logger.info('linkhelper started, device_id: {}'.format(self.device_id))
+        _logger.info('printer_discovery started, device_id: {}'.format(self.device_id))
 
         self.started_at = time.time()
         next_connect_at = 0.0  # -inf
@@ -68,7 +68,7 @@ class LinkHelper(object):
                 break
 
             if time.time() - self.started_at > self.deadline_secs:
-                _logger.info('linkhelper deadline reached')
+                _logger.info('printer_discovery deadline reached')
                 self.stop()
                 break
 
@@ -81,20 +81,20 @@ class LinkHelper(object):
                     backoff_time = ExpoBackoff.get_delay(
                         connect_attempts, self.max_backoff_secs)
                     _logger.debug(
-                        'linkhelper error ({}), will retry after {}s'.format(
+                        'printer_discovery error ({}), will retry after {}s'.format(
                             ex, backoff_time))
 
                     connect_attempts += 1
                     next_connect_at = time.time() + backoff_time
 
             time.sleep(2)
-        _logger.info('linkhelper stopped')
+        _logger.info('printer_discovery stopped')
 
     def stop(self):
         self.stopped = True
 
     def _call(self):
-        _logger.debug('linkhelper calls server')
+        _logger.debug('printer_discovery calls server')
         data = self._collect_device_info()
 
         resp = server_request(
@@ -115,7 +115,7 @@ class LinkHelper(object):
             self._process_message(msg)
 
     def _process_message(self, msg):
-        _logger.info('linkhelper incoming msg: {}'.format(msg))
+        _logger.info('printer_discovery incoming msg: {}'.format(msg))
 
         if msg['type'] == 'verify_code':
             # if any token is set, let's stop
@@ -123,15 +123,15 @@ class LinkHelper(object):
                 return
 
             if msg['device_id'] != self.device_id:
-                _logger.debug('linkhelper got message for different device_id')
+                _logger.debug('printer_discovery got message for different device_id')
                 return
 
             result = verify_code(self.plugin, msg['data'])
             if result['succeeded'] is True:
-                _logger.info('linkhelper verified code succesfully')
+                _logger.info('printer_discovery verified code succesfully')
                 self.stop()
             else:
-                _logger.warn('linkhelper could not verify code')
+                _logger.warn('printer_discovery could not verify code')
             return
 
     def _collect_device_info(self):

--- a/octoprint_thespaghettidetective/printer_discovery.py
+++ b/octoprint_thespaghettidetective/printer_discovery.py
@@ -50,7 +50,7 @@ class PrinterDiscovery(object):
             port=get_port(self.plugin) or 80,
         )
 
-        self.ip = None
+        self.host_or_ip = None
 
     def start(self):
         _logger.info('printer_discovery started, device_id: {}'.format(self.device_id))
@@ -138,9 +138,9 @@ class PrinterDiscovery(object):
         info = dict(**self.static_info)
         info['printerprofile'] = get_printerprofile_name()[:253]
 
-        if not self.ip:
-            self.ip = get_ip_addr()
-        info['ip'] = self.ip
+        if not self.host_or_ip:
+            self.host_or_ip = get_host_or_ip(self.plugin)
+        info['host_or_ip'] = self.host_or_ip
 
         info['machine_type'] = get_machine_type(self.plugin.octoprint_settings_updater)[:253]
 
@@ -181,11 +181,20 @@ def get_ip_addr():  # type () -> str
     return primary_ip
 
 
+def get_host_or_ip(plugin):
+    try:
+        discovery_settings = plugin._settings.global_get(['plugins', 'discovery'])
+        return discovery_settings.get('publicHost', get_ip_addr())
+    except Exception:
+        return ''
+
+
 def get_port(plugin):
     try:
-        return plugin.octoprint_port
+        discovery_settings = plugin._settings.global_get(['plugins', 'discovery'])
+        return discovery_settings.get('publicPort', plugin.octoprint_port)
     except Exception:
-        return None
+        return ''
 
 
 def get_machine_type(

--- a/octoprint_thespaghettidetective/utils.py
+++ b/octoprint_thespaghettidetective/utils.py
@@ -37,14 +37,19 @@ class ExpoBackoff:
 
     def more(self, e):
         self.attempts += 1
-        delay = 2 ** self.attempts
-        if delay > self.max_seconds:
-            delay = self.max_seconds
-        delay *= 0.5 + random.random()
-
+        delay = self.get_delay(self.attempts, self.max_seconds)
         _logger.error('Backing off %f seconds: %s' % (delay, e))
 
         time.sleep(delay)
+
+    @classmethod
+    def get_delay(cls, attempts, max_seconds):
+        delay = 2 ** attempts
+        if delay > max_seconds:
+            delay = max_seconds
+        delay *= 0.5 + random.random()
+        return delay
+
 
 class OctoPrintSettingsUpdater:
 


### PR DESCRIPTION
TSD plugin works only when an api token is present in the settings.
By default users have to "link" printers using octoprint ui by providing
a pin code. This can be tiresome.

If some condtion met, we can help to ease the pain and link the two legs
by a simple click.

This feature let unlinked printers poll server for a verification code.
Users can see their unlinked devices in the web/mobile app and are able
to link any of them with a single click.

Matching of users and devices is based on ip addresses.
Plugin provides some data about the device for easier identification
(hostname, os, version, printer profile, ...).