### PR TITLE
Use octo api endpoint for verification

### DIFF
--- a/octoprint_thespaghettidetective/plugin_apis.py
+++ b/octoprint_thespaghettidetective/plugin_apis.py
@@ -15,7 +15,7 @@ def get_api_commands():
 
 
 def verify_code(plugin, data):
-    resp = server_request('GET', '/api/v1/onetimeverificationcodes/verify/?code=' + data["code"], plugin)
+    resp = server_request('POST', '/api/v1/octo/verify/?code=' + data["code"], plugin)
     succeeded = resp.ok if resp is not None else None
     printer = None
     if succeeded:


### PR DESCRIPTION
Switched to POST method in verify call, that's "more correct
semantically".