### PR TITLE
Fixed loading spinner in frontends when video is disabled

### DIFF
--- a/octoprint_thespaghettidetective/janus.py
+++ b/octoprint_thespaghettidetective/janus.py
@@ -53,7 +53,7 @@ class JanusConn:
                         line = line.replace('{TURN_CREDENTIAL}', self.plugin._settings.get(["auth_token"]))
                         fout.write(line)
 
-            video_enabled = 'true' if self.plugin._settings.get(["disable_video_streaming"]) != 'true' else 'false'
+            video_enabled = 'true' if self.plugin._settings.get(["disable_video_streaming"]) not in ('true', True) else 'false'
             streaming_conf_tmp = os.path.join(JANUS_DIR, 'etc/janus/janus.plugin.streaming.jcfg.template')
             streaming_conf_path = os.path.join(JANUS_DIR, 'etc/janus/janus.plugin.streaming.jcfg')
             with open(streaming_conf_tmp, "rt") as fin:


### PR DESCRIPTION
When premium video is disabled, video stream should not be offered for frontends.

This comparison might have been buggy since the begining, or something else has changed. I don't know.
This is why I keep both values there to test against.