### PR TITLE
Fix server ws backoff bug + discovery backoff refactoring

### DIFF
--- a/octoprint_thespaghettidetective/utils.py
+++ b/octoprint_thespaghettidetective/utils.py
@@ -29,31 +29,26 @@ _logger = logging.getLogger('octoprint.plugins.thespaghettidetective')
 class ExpoBackoff:
 
     def __init__(self, max_seconds, max_attempts=0):
-        self.attempts = -3
+        self.attempts = 0
         self.max_seconds = max_seconds
         self.max_attempts = max_attempts
 
     def reset(self):
-        self.attempts = -3
+        self.attempts = 0
 
     def more(self, e):
         self.attempts += 1
-        if self.attempts > self.max_attempts:
-            _logger.error('Giving up on error: %s' % (e))
+        if self.max_attempts > 0 and self.attempts > self.max_attempts:
+            _logger.error('Giving up after %d attempts on error: %s' % (self.attempts, e))
             raise e
         else:
-            delay = self.get_delay(self.attempts, self.max_seconds)
-            _logger.error('Backing off %f seconds: %s' % (delay, e))
+            delay = 2 ** (self.attempts-3)
+            if delay > self.max_seconds:
+                delay = self.max_seconds
+            delay *= 0.5 + random.random()
+            _logger.error('Attempt %d - backing off %f seconds: %s' % (self.attempts, delay, e))
 
             time.sleep(delay)
-
-    @classmethod
-    def get_delay(cls, attempts, max_seconds):
-        delay = 2 ** attempts
-        if delay > max_seconds:
-            delay = max_seconds
-        delay *= 0.5 + random.random()
-        return delay
 
 
 class OctoPrintSettingsUpdater:

--- a/octoprint_thespaghettidetective/webcam_stream.py
+++ b/octoprint_thespaghettidetective/webcam_stream.py
@@ -231,7 +231,7 @@ class WebcamStreamer:
 
         def ensure_gst_process():
             ring_buffer = deque(maxlen=50)
-            gst_backoff = ExpoBackoff(60 * 10)
+            gst_backoff = ExpoBackoff(60 * 10, max_attempts=20)
             while True:
                 err = to_unicode(self.gst_proc.stderr.readline(), errors='replace')
                 if not err:  # EOF when process ends?

--- a/octoprint_thespaghettidetective/ws.py
+++ b/octoprint_thespaghettidetective/ws.py
@@ -24,7 +24,7 @@ class WebSocketClient:
                 on_ws_msg(ws, msg)
 
         def on_close(ws):
-            _logger.debug('WS Closed')
+            _logger.warning('WS Closed')
             if on_ws_close:
                 on_ws_close(ws)
 


### PR DESCRIPTION
Fixed the bug that caused server WS to be retried only 3 times.

Also simplified the logic for discovery loop and made it use ExpoBackoff in the consistent way with other parts of the code.