### PR TITLE
Fire custom events for printer commands

### DIFF
--- a/octoprint_thespaghettidetective/__init__.py
+++ b/octoprint_thespaghettidetective/__init__.py
@@ -76,6 +76,11 @@ class TheSpaghettiDetectivePlugin(
         self.client_conn = ClientConn(self)
         self.discovery = None
 
+    # ~~ Custom event registration
+
+    def register_custom_events(*args, **kwargs):
+      return ["start_print", "pause_print", "cancel_print", "resume_print"]
+
     # ~~ SettingsPlugin mixin
 
     def get_settings_defaults(self):
@@ -332,15 +337,19 @@ class TheSpaghettiDetectivePlugin(
                         self._printer_profile_manager.get_current_or_default(),
                         **command.get('args'))
                     self._printer.pause_print()
+                    self._event_bus.fire(octoprint.events.Events.PLUGIN_THESPAGHETTIDETECTIVE_PAUSE_PRINT, {})
 
                 if command["cmd"] == 'cancel':
                     self._printer.cancel_print()
+                    self._event_bus.fire(octoprint.events.Events.PLUGIN_THESPAGHETTIDETECTIVE_CANCEL_PRINT, {})
 
                 if command["cmd"] == 'resume':
                     self._printer.resume_print()
+                    self._event_bus.fire(octoprint.events.Events.PLUGIN_THESPAGHETTIDETECTIVE_RESUME_PRINT, {})
 
                 if command["cmd"] == 'print':
                     self.start_print(**command.get('args'))
+                    self._event_bus.fire(octoprint.events.Events.PLUGIN_THESPAGHETTIDETECTIVE_START_PRINT, {})
 
             if msg.get('passthru'):
                 self.client_conn.on_message_to_plugin(msg.get('passthru'))
@@ -462,4 +471,5 @@ def __plugin_load__():
         "octoprint.comm.protocol.gcode.queuing": __plugin_implementation__.commander.track_gcode,
         "octoprint.comm.protocol.scripts": (__plugin_implementation__.commander.script_hook, 100000),
         "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information,
+        "octoprint.events.register_custom_events": __plugin_implementation__.register_custom_events,
     }


### PR DESCRIPTION
This PR fires [custom events](https://docs.octoprint.org/en/master/plugins/hooks.html#sec-plugins-hook-events-register-custom-events) when changing the state of the printer. This lets other installed plugins respond to the detected spaghetti.

**Use Case:**

I'm a maintainer for the [Octoprint Continuous Print Plugin](https://github.com/smartin015/continuousprint), and I've been working on adding automatic retries when TSD detects a failure. My goal is for the plugin to cancel the print, clear the bed, and try it again when TSD detects spaghetti (with configurable limits on how long to try before giving up and trying another print file, or stopping entirely).

Right now, it treats the job being paused as "spaghetti detected", regardless of whether it happened via TSD, manual input, or some other source. I'd like to refine this so that only print pauses related to spaghetti detection are acted upon, and so that manual input isn't treated as retriable.

My first  approach was to try passing `tags` to the print commands - but these tags are swallowed within octoprint itself and not forwarded to plugins that use the event listener. It appears this is the best way to indicate TSD-specific actions without substantial modifications to how octoprint handles events internally.

**Tests:**

I've verified this works on a Pi 4 with Octoprint v1.7.3. The events are indeed passed to the `on_event()` handler within my plugin.