### PR TITLE
Collapse custom events into single event; include command data

### DIFF
--- a/octoprint_thespaghettidetective/__init__.py
+++ b/octoprint_thespaghettidetective/__init__.py
@@ -79,7 +79,7 @@ class TheSpaghettiDetectivePlugin(
     # ~~ Custom event registration
 
     def register_custom_events(*args, **kwargs):
-      return ["start_print", "pause_print", "cancel_print", "resume_print"]
+      return ["command"]
 
     # ~~ SettingsPlugin mixin
 
@@ -331,25 +331,23 @@ class TheSpaghettiDetectivePlugin(
 
             need_status_boost = False
             for command in msg.get('commands', []):
+                self._event_bus.fire(octoprint.events.Events.PLUGIN_THESPAGHETTIDETECTIVE_COMMAND, command)
+
                 if command["cmd"] == "pause":
                     self.commander.prepare_to_pause(
                         self._printer,
                         self._printer_profile_manager.get_current_or_default(),
                         **command.get('args'))
                     self._printer.pause_print()
-                    self._event_bus.fire(octoprint.events.Events.PLUGIN_THESPAGHETTIDETECTIVE_PAUSE_PRINT, {})
 
                 if command["cmd"] == 'cancel':
                     self._printer.cancel_print()
-                    self._event_bus.fire(octoprint.events.Events.PLUGIN_THESPAGHETTIDETECTIVE_CANCEL_PRINT, {})
 
                 if command["cmd"] == 'resume':
                     self._printer.resume_print()
-                    self._event_bus.fire(octoprint.events.Events.PLUGIN_THESPAGHETTIDETECTIVE_RESUME_PRINT, {})
 
                 if command["cmd"] == 'print':
                     self.start_print(**command.get('args'))
-                    self._event_bus.fire(octoprint.events.Events.PLUGIN_THESPAGHETTIDETECTIVE_START_PRINT, {})
 
             if msg.get('passthru'):
                 self.client_conn.on_message_to_plugin(msg.get('passthru'))


### PR DESCRIPTION
Refactor of #157. This now passes command data via a singular "command" event, rather than having custom events for each command. 

This is a net reduction in code, yet allows for further inspecting/filtering on different TSD events based on command data.

I've confirmed this runs experimentally on my octopi installation.